### PR TITLE
Fixed some bugs 🐛 I created the .volt file in my home dir (linux user)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
   "name": "volt",
   "version": "1.0.0",
-  "description": "a package manager",
+  "description": "",
   "main": "index.js",
   "repository": "",
-  "author": "Shadow7258 <pranav.rdoshi@gmail.com>",
+  "author": "VarunPotti <potti.varun07@gmail.com>",
   "license": "Apache2",
-  "private": false,
-  "dependencies": {
-    "react": "^17.0.2"
-  }
+  "private": false
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,7 @@
 #[path = "../classes/init_data.rs"]
 mod init_data;
-
+#[path = "../utils.rs"]
+mod utilities;
 use crate::{
     commands::init::init_data::License,
     prompt::prompt::{Confirm, Input, Select},
@@ -45,7 +46,8 @@ Options:
     }
 
     async fn exec(&self, _app: Arc<App>, _args: Vec<String>, flags: Vec<String>) {
-        let temp = env::current_dir().unwrap().to_string_lossy().to_string();
+        let temp =
+            utilities::get_basename(&env::current_dir().unwrap().to_string_lossy()).to_string();
         let split: Vec<&str> = temp.split(r"\").collect::<Vec<&str>>();
         let cwd: String = split[split.len() - 1].to_string();
 


### PR DESCRIPTION
```rust
pub fn get_basename<'a>(path: &'a str) -> Cow<'a, str> {
    let sep: char;
    if cfg!(windows) {
        sep = '\\';
    } else {
        sep = '/';
    }
    let mut pieces = path.rsplit(sep);

    match pieces.next() {
        Some(p) => p.into(),
        None => path.into(),
    }
}
``` 
This is there in utils.rs file and used in init.rs. It gets the basename of the dir (copied from my previous node package manager mbrew)